### PR TITLE
Move some things around

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ A simple example should show how to do it.
 ### Areabrick Class
 
 Your areabrick class must implement Pimcore's `Pimcore\Extension\Document\Areabrick\EditableDialogBoxInterface` interface
-and additionally use the `Neusta\Pimcore\AreabrickConfigBundle\Document\Base\HasDialogBox` trait. 
+and additionally use the `Neusta\Pimcore\AreabrickConfigBundle\HasDialogBox` trait. 
 
 Then it's up to you to implement the `buildDialogBox()` method as you wish.
 
 ```php
 <?php
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\Base\HasDialogBox;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\DialogBoxBuilder;
+use Neusta\Pimcore\AreabrickConfigBundle\DialogBoxBuilder;
+use Neusta\Pimcore\AreabrickConfigBundle\HasDialogBox;
 use Pimcore\Extension\Document\Areabrick\AbstractTemplateAreabrick;
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxInterface;
 use Pimcore\Model\Document\Editable;

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class MyAreabrick extends AbstractTemplateAreabrick implements EditableDialogBox
     /******************************************************************
      * This is the code you have to implement
      *****************************************************************/
-    protected function buildDialogBox(DialogBoxBuilder $dialogBox, Editable $area, ?Info $info): void
+    private function buildDialogBox(DialogBoxBuilder $dialogBox, Editable $area, ?Info $info): void
     {
         $dialogBox
             ->addTab('Einstellungen meines Bricks',

--- a/src/DialogBoxBuilder.php
+++ b/src/DialogBoxBuilder.php
@@ -2,13 +2,13 @@
 
 namespace Neusta\Pimcore\AreabrickConfigBundle;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\CheckboxItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\InputItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\RelationItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\SelectItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\LayoutItem\PanelItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\LayoutItem\TabPanelItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\CheckboxItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\InputItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\RelationItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\SelectItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem\PanelItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem\TabPanelItem;
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration;
 
 class DialogBoxBuilder

--- a/src/DialogBoxBuilder.php
+++ b/src/DialogBoxBuilder.php
@@ -1,7 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox;
+namespace Neusta\Pimcore\AreabrickConfigBundle;
 
+use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
 use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\CheckboxItem;
 use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\InputItem;
 use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem\RelationItem;

--- a/src/EditableDialogBox/DialogBoxItem.php
+++ b/src/EditableDialogBox/DialogBoxItem.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 
 abstract class DialogBoxItem
 {

--- a/src/EditableDialogBox/EditableItem.php
+++ b/src/EditableDialogBox/EditableItem.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 
 class EditableItem extends DialogBoxItem
 {

--- a/src/EditableDialogBox/EditableItem/CheckboxItem.php
+++ b/src/EditableDialogBox/EditableItem/CheckboxItem.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class CheckboxItem extends EditableItem
 {

--- a/src/EditableDialogBox/EditableItem/InputItem.php
+++ b/src/EditableDialogBox/EditableItem/InputItem.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class InputItem extends EditableItem
 {

--- a/src/EditableDialogBox/EditableItem/RelationItem.php
+++ b/src/EditableDialogBox/EditableItem/RelationItem.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class RelationItem extends EditableItem
 {

--- a/src/EditableDialogBox/EditableItem/SelectItem.php
+++ b/src/EditableDialogBox/EditableItem/SelectItem.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\EditableItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class SelectItem extends EditableItem
 {

--- a/src/EditableDialogBox/LayoutItem.php
+++ b/src/EditableDialogBox/LayoutItem.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 
 abstract class LayoutItem extends DialogBoxItem
 {

--- a/src/EditableDialogBox/LayoutItem/PanelItem.php
+++ b/src/EditableDialogBox/LayoutItem/PanelItem.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\LayoutItem;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\DialogBoxItem;
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\LayoutItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\DialogBoxItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
 
 class PanelItem extends LayoutItem
 {

--- a/src/EditableDialogBox/LayoutItem/TabPanelItem.php
+++ b/src/EditableDialogBox/LayoutItem/TabPanelItem.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\LayoutItem;
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\LayoutItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
 
 class TabPanelItem extends LayoutItem
 {

--- a/src/HasDialogBox.php
+++ b/src/HasDialogBox.php
@@ -1,8 +1,7 @@
 <?php declare(strict_types=1);
 
-namespace Neusta\Pimcore\AreabrickConfigBundle\Document\Base;
+namespace Neusta\Pimcore\AreabrickConfigBundle;
 
-use Neusta\Pimcore\AreabrickConfigBundle\Document\EditableDialogBox\DialogBoxBuilder;
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration;
 use Pimcore\Model\Document\Editable;
 use Pimcore\Model\Document\Editable\Area\Info;

--- a/src/HasDialogBox.php
+++ b/src/HasDialogBox.php
@@ -23,7 +23,7 @@ trait HasDialogBox
     /**
      * @return T
      */
-    protected function createDialogBoxBuilder(Editable $area, ?Info $info): DialogBoxBuilder
+    private function createDialogBoxBuilder(Editable $area, ?Info $info): DialogBoxBuilder
     {
         return new DialogBoxBuilder();
     }
@@ -31,5 +31,5 @@ trait HasDialogBox
     /**
      * @param T $dialogBox
      */
-    abstract protected function buildDialogBox(DialogBoxBuilder $dialogBox, Editable $area, ?Info $info): void;
+    abstract private function buildDialogBox(DialogBoxBuilder $dialogBox, Editable $area, ?Info $info): void;
 }


### PR DESCRIPTION
Moves entry points to the root and removes the `\Document\` part from the namespace.