### PR TITLE
Move type declaration to constant instead of constructor parameter.

### DIFF
--- a/src/EditableDialogBox/DialogBoxItem.php
+++ b/src/EditableDialogBox/DialogBoxItem.php
@@ -5,15 +5,18 @@ namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 
 abstract class DialogBoxItem
 {
+    public const TYPE = '';
     public const ITEM_CONFIG = 'config';
     public const ITEM_LABEL = 'label';
     public const ITEM_NAME = 'name';
     public const ITEM_TYPE = 'type';
     public const ITEM_DEFAULT_VALUE = 'defaultValue';
 
+    private string $type;
+
     public function __construct(
-        private string $type,
     ) {
+        $this->type = static::TYPE;
     }
 
     /**

--- a/src/EditableDialogBox/EditableItem.php
+++ b/src/EditableDialogBox/EditableItem.php
@@ -5,14 +5,16 @@ namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 
 class EditableItem extends DialogBoxItem
 {
+    public const TYPE = 'editable';
+
     private string $name;
     private string $label = '';
     /** @var array<string, bool|float|int|string> */
     private array $config = [];
 
-    public function __construct(string $type, string $name)
+    public function __construct(string $name)
     {
-        parent::__construct($type);
+        parent::__construct();
         $this->name = $name;
     }
 

--- a/src/EditableDialogBox/EditableItem/CheckboxItem.php
+++ b/src/EditableDialogBox/EditableItem/CheckboxItem.php
@@ -7,9 +7,11 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class CheckboxItem extends EditableItem
 {
+    public const TYPE = 'checkbox';
+
     public function __construct(string $name)
     {
-        parent::__construct('checkbox', $name);
+        parent::__construct($name);
     }
 
     public function setDefaultChecked(): static

--- a/src/EditableDialogBox/EditableItem/InputItem.php
+++ b/src/EditableDialogBox/EditableItem/InputItem.php
@@ -7,9 +7,11 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class InputItem extends EditableItem
 {
+    public const TYPE = 'input';
+
     public function __construct(string $name)
     {
-        parent::__construct('input', $name);
+        parent::__construct($name);
     }
 
     public function setDefaultValue(string $value): static

--- a/src/EditableDialogBox/EditableItem/NumericItem.php
+++ b/src/EditableDialogBox/EditableItem/NumericItem.php
@@ -7,6 +7,7 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class NumericItem extends EditableItem
 {
+    public const TYPE = 'numeric';
     public const ITEM_MIN_VALUE = 'minValue';
     public const ITEM_MAX_VALUE = 'maxValue';
     private int $min = 0;
@@ -14,7 +15,7 @@ class NumericItem extends EditableItem
 
     public function __construct(string $name, int $min, int $max)
     {
-        parent::__construct('numeric', $name);
+        parent::__construct($name);
         $this->min = $min;
         $this->max = $max;
         $this->setDefaultValue($this->min);

--- a/src/EditableDialogBox/EditableItem/RelationItem.php
+++ b/src/EditableDialogBox/EditableItem/RelationItem.php
@@ -7,6 +7,8 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class RelationItem extends EditableItem
 {
+    public const TYPE = 'relation';
+
     /** @var array{asset?: list<string>, document?: list<string>, object?: list<string>} */
     private array $types = [];
     /** @var list<string> */
@@ -14,7 +16,7 @@ class RelationItem extends EditableItem
 
     public function __construct(string $name)
     {
-        parent::__construct('relation', $name);
+        parent::__construct($name);
     }
 
     public function allowAssetsOfType(string ...$types): static

--- a/src/EditableDialogBox/EditableItem/SelectItem.php
+++ b/src/EditableDialogBox/EditableItem/SelectItem.php
@@ -7,6 +7,8 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 
 class SelectItem extends EditableItem
 {
+    public const TYPE = 'select';
+
     /** @var list<array{array-key, string}> */
     private array $store = [];
 
@@ -15,7 +17,7 @@ class SelectItem extends EditableItem
      */
     public function __construct(string $name, array $store)
     {
-        parent::__construct('select', $name);
+        parent::__construct($name);
         $this->store = self::pack($store);
         $this->setDefaultValue(array_key_first($store));
     }

--- a/src/EditableDialogBox/LayoutItem.php
+++ b/src/EditableDialogBox/LayoutItem.php
@@ -5,14 +5,15 @@ namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 
 abstract class LayoutItem extends DialogBoxItem
 {
+    public const TYPE = 'layout';
+
     /**
      * @param list<DialogBoxItem> $items
      */
     public function __construct(
-        string $type,
         private array $items,
     ) {
-        parent::__construct($type);
+        parent::__construct();
     }
 
     public function isEmpty(): bool

--- a/src/EditableDialogBox/LayoutItem/PanelItem.php
+++ b/src/EditableDialogBox/LayoutItem/PanelItem.php
@@ -8,6 +8,7 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
 
 class PanelItem extends LayoutItem
 {
+    public const TYPE = 'panel';
     private string $title;
 
     /**
@@ -15,7 +16,7 @@ class PanelItem extends LayoutItem
      */
     public function __construct(string $title, array $items)
     {
-        parent::__construct('panel', $items);
+        parent::__construct($items);
         $this->title = $title;
     }
 

--- a/src/EditableDialogBox/LayoutItem/TabPanelItem.php
+++ b/src/EditableDialogBox/LayoutItem/TabPanelItem.php
@@ -7,12 +7,13 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
 
 class TabPanelItem extends LayoutItem
 {
+    public const TYPE = 'tabpanel';
     /**
      * @param list<PanelItem> $items
      */
     public function __construct(array $items = [])
     {
-        parent::__construct('tabpanel', $items);
+        parent::__construct($items);
     }
 
     public function addTab(PanelItem $tab): static


### PR DESCRIPTION
What are you thinking about that declaration?!
Type parameter could be skipped and be consistent everywhere (by using right EditableItem type/class automatically)