### PR TITLE
Remove default values of `DialogBoxBuilder` and add `reloadOnClose()` method

### DIFF
--- a/src/DialogBoxBuilder.php
+++ b/src/DialogBoxBuilder.php
@@ -13,19 +13,20 @@ use Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration;
 
 class DialogBoxBuilder
 {
-    private const DEFAULT_RELOAD_ON_CLOSE = true;
-    private const DEFAULT_WIDTH = 600;
-
     private EditableDialogBoxConfiguration $config;
     private TabPanelItem $tabs;
 
     public function __construct()
     {
         $this->config = new EditableDialogBoxConfiguration();
-        $this->config->setReloadOnClose(self::DEFAULT_RELOAD_ON_CLOSE);
-        $this->config->setWidth(self::DEFAULT_WIDTH);
-
         $this->tabs = new TabPanelItem();
+    }
+
+    public function reloadOnClose(bool $reload = true): static
+    {
+        $this->config->setReloadOnClose($reload);
+
+        return $this;
     }
 
     public function width(int $width): static


### PR DESCRIPTION
I don't think we should set (opinionated) default values for the editable config dialog in this bundle, as this can be project specific.

If a project wants to set default values, it can overwrite the `HasDialogBox::createDialogBoxBuilder()` method as follows:

```php
private function createDialogBoxBuilder(Editable $area, ?Info $info): DialogBoxBuilder
{
    return (new DialogBoxBuilder())
        ->reloadOnClose()
        ->width(600);
}
```