### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class MyAreabrick extends AbstractTemplateAreabrick implements EditableDialogBox
     /******************************************************************
      * This is the code you have to implement
      *****************************************************************/
-    private function buildDialogBox(DialogBoxBuilder $dialogBox, Editable $area, ?Info $info): void
+    protected function buildDialogBox(DialogBoxBuilder $dialogBox, Editable $area, ?Info $info): void
     {
         $dialogBox
             ->addTab('Einstellungen meines Bricks',


### PR DESCRIPTION
The method which should be overwritten has to be protected NOT private.