### PR TITLE
Add date and link items

### DIFF
--- a/src/DialogBoxBuilder.php
+++ b/src/DialogBoxBuilder.php
@@ -4,6 +4,7 @@ namespace Neusta\Pimcore\AreabrickConfigBundle;
 
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\CheckboxItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\DateItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\InputItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\NumericItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\RelationItem;
@@ -89,6 +90,11 @@ class DialogBoxBuilder
     public function createNumeric(string $name, int $min, int $max): NumericItem
     {
         return new NumericItem($name, $min, $max);
+    }
+
+    public function createDate(string $name): DateItem
+    {
+        return new DateItem($name);
     }
 
     public function build(): EditableDialogBoxConfiguration

--- a/src/DialogBoxBuilder.php
+++ b/src/DialogBoxBuilder.php
@@ -6,6 +6,7 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\CheckboxItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\DateItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\InputItem;
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\LinkItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\NumericItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\RelationItem;
 use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\SelectItem;
@@ -95,6 +96,11 @@ class DialogBoxBuilder
     public function createDate(string $name): DateItem
     {
         return new DateItem($name);
+    }
+
+    public function createLink(string $name): LinkItem
+    {
+        return new LinkItem($name);
     }
 
     public function build(): EditableDialogBoxConfiguration

--- a/src/EditableDialogBox/EditableItem/DateItem.php
+++ b/src/EditableDialogBox/EditableItem/DateItem.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
+
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
+
+class DateItem extends EditableItem
+{
+    public function __construct(string $name)
+    {
+        parent::__construct('date', $name);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDefaultValue(string $value): static
+    {
+        return $this->addConfig('defaultValue', $value);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFormat(string $value): static
+    {
+        return $this->addConfig('format', $value);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setOutputFormat(string $value): static
+    {
+        return $this->addConfig('outputFormat', $value);
+    }
+}

--- a/src/EditableDialogBox/EditableItem/LinkItem.php
+++ b/src/EditableDialogBox/EditableItem/LinkItem.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
+
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
+
+class LinkItem extends EditableItem
+{
+    public function __construct(string $name)
+    {
+        parent::__construct('link', $name);
+    }
+}


### PR DESCRIPTION
Adds (basic) support for the [Date](https://pimcore.com/docs/platform/Pimcore/Documents/Editables/Date/) and [Link](https://pimcore.com/docs/platform/Pimcore/Documents/Editables/Link/) editables.