### PR TITLE
fix: accordion click handler should only target buttons

### DIFF
--- a/public/js/areabrick-overview-unpublished-toggle.js
+++ b/public/js/areabrick-overview-unpublished-toggle.js
@@ -1,5 +1,9 @@
 document.addEventListener('DOMContentLoaded', function () {
     document.addEventListener('click', event => {
+        if (event.target.tagName !== 'BUTTON') {
+            return;
+        }
+
         const el = event.target.closest('#neusta_areabrick_config .accordion');
 
         if (el) {


### PR DESCRIPTION
Currently, the accordion collapses when, e.g., a link inside it is clicked.