### PR TITLE
feat(areabrick-overview): automatic colors for additional properties

### DIFF
--- a/public/css/admin-style.css
+++ b/public/css/admin-style.css
@@ -58,6 +58,10 @@
 }
 
 /* Additional Properties */
+#neusta_areabrick_config ul.additional-properties {
+    padding: 0;
+}
+
 #neusta_areabrick_config ul.additional-properties li {
     list-style-type: none;
     margin-left: 5px;
@@ -65,15 +69,6 @@
     padding: 2px 4px;
     border-radius: 3px;
     display: inline-block;
-    color: #ffffff;
-}
-
-#neusta_areabrick_config ul.additional-properties li.tag {
-    background-color: #2a6f9c;
-}
-
-#neusta_areabrick_config ul.additional-properties li.group {
-    background-color: #194567;
 }
 
 #neusta_areabrick_config ul.additional-properties li.empty {

--- a/public/css/admin-style.css
+++ b/public/css/admin-style.css
@@ -64,11 +64,14 @@
 
 #neusta_areabrick_config ul.additional-properties li {
     list-style-type: none;
-    margin-left: 5px;
-    width: 150px;
+    width: 100%;
     padding: 2px 4px;
     border-radius: 3px;
     display: inline-block;
+}
+
+#neusta_areabrick_config ul.additional-properties li + li {
+    margin-top: 3px;
 }
 
 #neusta_areabrick_config ul.additional-properties li.empty {

--- a/public/js/areabrick-overview.js
+++ b/public/js/areabrick-overview.js
@@ -43,7 +43,11 @@ neusta.areabrick_config.areabrick_overview = Class.create({
                         .querySelectorAll('#neusta_areabrick_config ul.additional-properties > li')
                         .forEach(el => {
                             const name = el.querySelector('span').textContent;
-                            const rgb = this.hslToRgb(this.textToHSL(name));
+                            const rgb = this.hslToRgb(this.textToHSL(name, {
+                                hue: [190,220],
+                                sat: [60,80],
+                                lit: [30,70],
+                            }));
 
                             el.style.backgroundColor = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
                             el.style.color = this.contrastingColor(rgb);

--- a/public/js/areabrick-overview.js
+++ b/public/js/areabrick-overview.js
@@ -39,25 +39,13 @@ neusta.areabrick_config.areabrick_overview = Class.create({
                         autoScroll: true,
                     });
 
-                    document.getElementById(this.tabId)
-                        .querySelectorAll('#neusta_areabrick_config ul.additional-properties > li')
-                        .forEach(el => {
-                            const name = el.querySelector('span').textContent;
-                            const rgb = this.hslToRgb(this.textToHSL(name, {
-                                hue: [190,220],
-                                sat: [60,80],
-                                lit: [30,70],
-                            }));
-
-                            el.style.backgroundColor = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
-                            el.style.color = this.contrastingColor(rgb);
-                        });
+                    this.colorizeAdditionalProperties();
                 }.bind(this),
             });
 
             this.handleClick('#neusta_areabrick_config a[data-page-id]', el => {
                 pimcore.helpers.openDocument(el.dataset.pageId, el.dataset.pageType);
-            })
+            });
         }
 
         return this.panel;
@@ -71,6 +59,22 @@ neusta.areabrick_config.areabrick_overview = Class.create({
                 handler(el, event);
             }
         });
+    },
+
+    colorizeAdditionalProperties: function () {
+        document.getElementById(this.tabId)
+            .querySelectorAll('#neusta_areabrick_config ul.additional-properties > li:not(.empty)')
+            .forEach(el => {
+                const name = el.querySelector('span').textContent;
+                const rgb = this.hslToRgb(this.textToHSL(name, {
+                    hue: [190,220],
+                    sat: [60,80],
+                    lit: [30,70],
+                }));
+
+                el.style.backgroundColor = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+                el.style.color = this.contrastingColor(rgb);
+            });
     },
 
     // https://gist.github.com/0x263b/2bdd90886c2036a1ad5bcf06d6e6fb37#hsl

--- a/public/js/areabrick-overview.js
+++ b/public/js/areabrick-overview.js
@@ -38,6 +38,22 @@ neusta.areabrick_config.areabrick_overview = Class.create({
                         html: response.responseText,
                         autoScroll: true,
                     });
+
+                    document.getElementById(this.tabId)
+                        .querySelectorAll('#neusta_areabrick_config .accordion a')
+                        .forEach(el => {
+                            const bgColor = this.toHSL(el.textContent);
+                            // The threshold at which colors are considered "light."
+                            // Range: integers from 0 to 100, recommended 50-70.
+                            // Any lightness value below the threshold will result in white,
+                            // any above will result in black.
+                            const threshold = 50;
+
+                            el.style.backgroundColor = `hsl(${bgColor.h}, ${bgColor.s}%, ${bgColor.l}%)`;
+                            // https://css-tricks.com/switch-font-color-for-different-backgrounds-with-css/#aa-applying-the-trick-to-our-font-color-declaration
+                            // soon™: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast
+                            el.style.color = `hsl(0, 0%, calc((${bgColor.l} - ${threshold}) * -100%))`;
+                        })
                 }.bind(this),
             });
 
@@ -57,6 +73,33 @@ neusta.areabrick_config.areabrick_overview = Class.create({
                 handler(el, event);
             }
         });
+    },
+
+    // https://gist.github.com/0x263b/2bdd90886c2036a1ad5bcf06d6e6fb37
+    toHSL: function (string, opts) {
+        opts = opts || {};
+        opts.hue = opts.hue || [0, 360];
+        opts.sat = opts.sat || [75, 100];
+        opts.lit = opts.lit || [40, 60];
+
+        const range = function (hash, min, max) {
+            const diff = max - min
+            const x = ((hash % diff) + diff) % diff
+
+            return x + min
+        };
+
+        let hash = 0
+        for (let i = 0; i < string.length; i++) {
+            hash = string.charCodeAt(i) + ((hash << 5) - hash);
+            hash = hash & hash;
+        }
+
+        const h = range(hash, opts.hue[0], opts.hue[1]);
+        const s = range(hash, opts.sat[0], opts.sat[1]);
+        const l = range(hash, opts.lit[0], opts.lit[1]);
+
+        return {h, s, l};
     },
 
 });

--- a/public/js/areabrick-overview.js
+++ b/public/js/areabrick-overview.js
@@ -40,14 +40,14 @@ neusta.areabrick_config.areabrick_overview = Class.create({
                     });
 
                     document.getElementById(this.tabId)
-                        .querySelectorAll('#neusta_areabrick_config .accordion a')
+                        .querySelectorAll('#neusta_areabrick_config ul.additional-properties > li')
                         .forEach(el => {
-                            const hsl = this.toHSL(el.textContent);
-                            const rgb = this.hslToRgb(hsl.h / 360, hsl.s / 100, hsl.l / 100);
+                            const name = el.querySelector('span').textContent;
+                            const rgb = this.hslToRgb(this.textToHSL(name));
 
-                            el.style.backgroundColor = `hsl(${hsl.h}, ${hsl.s}%, ${hsl.l}%)`;
-                            el.style.color = this.textColorBasedOnBackground(rgb.r, rgb.g, rgb.b);
-                        })
+                            el.style.backgroundColor = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+                            el.style.color = this.contrastingColor(rgb);
+                        });
                 }.bind(this),
             });
 
@@ -69,85 +69,67 @@ neusta.areabrick_config.areabrick_overview = Class.create({
         });
     },
 
-    // https://gist.github.com/0x263b/2bdd90886c2036a1ad5bcf06d6e6fb37
-    toHSL: function (string, opts) {
-        opts = opts || {};
-        opts.hue = opts.hue || [0, 360];
-        opts.sat = opts.sat || [75, 100];
-        opts.lit = opts.lit || [40, 60];
+    // https://gist.github.com/0x263b/2bdd90886c2036a1ad5bcf06d6e6fb37#hsl
+    textToHSL: function (string, opts = {}) {
+        const hash = [...string].reduce((s, c) => Math.imul(31, s) + c.charCodeAt(0) | 0, 0);
+        const {
+            hue = [0, 360],
+            sat = [0, 100],
+            lit = [0, 100],
+        } = opts;
 
-        const range = function (hash, min, max) {
-            const diff = max - min
-            const x = ((hash % diff) + diff) % diff
+        function range(num, min, max) {
+            const diff = max - min;
 
-            return x + min
-        };
-
-        let hash = 0
-        for (let i = 0; i < string.length; i++) {
-            hash = string.charCodeAt(i) + ((hash << 5) - hash);
-            hash = hash & hash;
-        }
-
-        const h = range(hash, opts.hue[0], opts.hue[1]);
-        const s = range(hash, opts.sat[0], opts.sat[1]);
-        const l = range(hash, opts.lit[0], opts.lit[1]);
-
-        return {h, s, l};
-    },
-
-    // https://stackoverflow.com/a/9493060
-    /**
-     * Converts an HSL color value to RGB. Conversion formula
-     * adapted from https://en.wikipedia.org/wiki/HSL_color_space.
-     * Assumes h, s, and l are contained in the set [0, 1] and
-     * returns r, g, and b in the set [0, 255].
-     *
-     * @param   {number}  h                         The hue
-     * @param   {number}  s                         The saturation
-     * @param   {number}  l                         The lightness
-     * @return  {{r: number, g: number, b: number}} The RGB representation
-     */
-    hslToRgb: function (h, s, l) {
-        const {round} = Math
-        let r, g, b
-
-        function hueToRgb(p, q, t) {
-            if (t < 0) t += 1
-            if (t > 1) t -= 1
-            if (t < 1 / 6) return p + (q - p) * 6 * t
-            if (t < 1 / 2) return q
-            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
-            return p
-        }
-
-        if (s === 0) {
-            r = g = b = l // achromatic
-        } else {
-            const q = l < 0.5 ? l * (1 + s) : l + s - l * s
-            const p = 2 * l - q
-            r = hueToRgb(p, q, h + 1 / 3)
-            g = hueToRgb(p, q, h)
-            b = hueToRgb(p, q, h - 1 / 3)
+            return (((num % diff) + diff) % diff) + min;
         }
 
         return {
-            r: round(r * 255),
-            g: round(g * 255),
-            b: round(b * 255),
+            h: range(hash, hue[0], hue[1]),
+            s: range(hash, sat[0], sat[1]),
+            l: range(hash, lit[0], lit[1]),
+        };
+    },
+
+    // https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB_alternative
+    hslToRgb: function (hsl) {
+        const h = hsl.h;
+        const s = hsl.s / 100;
+        const l = hsl.l / 100;
+
+        function f(n) {
+            const k = (n + h / 30) % 12;
+            const a = s * Math.min(l, 1 - l);
+
+            return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
         }
+
+        return {
+            r: Math.round(f(0) * 255),
+            g: Math.round(f(8) * 255),
+            b: Math.round(f(4) * 255),
+        };
+    },
+
+    // https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+    rgbToRelativeLuminance: function (rgb) {
+        const srgb = this.mapObject(rgb, c => c / 255);
+        const {r, g, b} = this.mapObject(srgb, c => {
+            return c <= 0.04045
+                ? c / 12.92
+                : ((c + 0.055) / 1.055) ** 2.4;
+        });
+
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
     },
 
     // https://dev.to/louis7/how-to-choose-the-font-color-based-on-the-background-color-402a
-    textColorBasedOnBackground: function (r, g, b) {
-        const srgb = [r / 255, g / 255, b / 255];
-        const x = srgb.map((i) => {
-            return i <= 0.04045 ? i / 12.92 : Math.pow((i + 0.055) / 1.055, 2.4);
-        })
+    contrastingColor: function (rgb) {
+        return this.rgbToRelativeLuminance(rgb) > 0.179 ? '#000' : '#fff';
+    },
 
-        const L = 0.2126 * x[0] + 0.7152 * x[1] + 0.0722 * x[2];
-
-        return L > 0.179 ? "#000" : "#fff";
+    mapObject: function (obj, func) {
+        return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, func(v)]));
     },
 
 });

--- a/templates/bricks/overview.html.twig
+++ b/templates/bricks/overview.html.twig
@@ -60,9 +60,7 @@
                     <td>
                         <ul class="additional-properties">
                             {% for additionalProperty in brick.additionalProperties|default([]) %}
-                                <li class="{% if additionalProperty.name == 'tags' %}tag{% elseif additionalProperty.name == 'groups' %}group{% endif %}">
-                                    {{ additionalProperty.name }}: {{ additionalProperty.value }}
-                                </li>
+                                <li><span>{{ additionalProperty.name }}</span>: {{ additionalProperty.value }}</li>
                             {% else %}
                                 <li class="empty">{{ 'neusta_pimcore_areabrick_config.areabricks.overview.table.no_additional_properties'|trans }}</li>
                             {% endfor %}


### PR DESCRIPTION
Currently, only additional properties with name `tags` and `groups` are colored.

This PR adds an algorithm that automatically colors _any_ tag depending on its `name`. This works by hashing the `name` and converting the resulting hash to an HSL color within a given range (which allows us to only create blueish colors, for example).

Then the luminosity of the background color is determined to decide whether the text should be displayed in white or black.

Currently, only bluish colors are generated (see https://github.com/teamneusta/pimcore-areabrick-config-bundle/pull/35/commits/3873a6f82c3d1823f52155b71c13b651bbe4e43c):

![grafik](https://github.com/user-attachments/assets/b5626499-c983-43b3-9277-23f8495be0d9)

Resolves #25