### PR TITLE
Pimcore Editable Numeric uses string values

### DIFF
--- a/src/EditableDialogBox/EditableItem/NumericItem.php
+++ b/src/EditableDialogBox/EditableItem/NumericItem.php
@@ -27,14 +27,14 @@ class NumericItem extends EditableItem
             throw new \InvalidArgumentException(\sprintf('Default value "%d" is out of bounds: [%d,%d]', $value, $this->min, $this->max));
         }
 
-        return $this->addConfig('defaultValue', $value);
+        return $this->addConfig('defaultValue', (string) $value);
     }
 
     protected function getConfig(): array
     {
         return [
-            'minValue' => $this->min,
-            'maxValue' => $this->max,
+            'minValue' => (string) $this->min,
+            'maxValue' => (string) $this->max,
         ];
     }
 }


### PR DESCRIPTION
Internally Pimcore uses string in the Numeric Editable - so we have to cast it:
```
namespace Pimcore\Model\Document\Editable;

use Pimcore\Model;

/**
 * @method \Pimcore\Model\Document\Editable\Dao getDao()
 */
class Numeric extends Model\Document\Editable
{
    /**
     * Contains the current number, or an empty string if not set
     *
     * @internal
     */
    protected ?string $number = null;

    ...

    /**
     * @see EditableInterface::getData
     *
     */
    public function getNumber(): string
    {
        return $this->getData();
    }

    public function frontend()
    {
        return $this->number;
    }

    public function setDataFromResource(mixed $data): static
    {
        $this->number = $data; // <-- here we are running into problems not to cast to string.

        return $this;
    }

    public function setDataFromEditmode(mixed $data): static
    {
        $this->number = (string)$data;

        return $this;
    }

    public function isEmpty(): bool
    {
        if (is_numeric($this->number)) {
            return false;
        }

        return empty($this->number);
    }
}

```