### PR TITLE
Pimcore Numeric Editable uses `string` instead of `int`

### DIFF
--- a/src/EditableDialogBox/EditableItem/NumericItem.php
+++ b/src/EditableDialogBox/EditableItem/NumericItem.php
@@ -33,8 +33,8 @@ class NumericItem extends EditableItem
     protected function getConfig(): array
     {
         return [
-            'minValue' => (string) $this->min,
-            'maxValue' => (string) $this->max,
+            'minValue' => $this->min,
+            'maxValue' => $this->max,
         ];
     }
 }


### PR DESCRIPTION
For `defaultValue` a `string` has to be set.
So our `NumericItem` has to set the `defaultValue` with cast to `string`.

This is a followup of #39.