### PR TITLE
[Fix] Initialize $items before reading

### DIFF
--- a/src/EditableDialogBox/LayoutItem.php
+++ b/src/EditableDialogBox/LayoutItem.php
@@ -9,7 +9,7 @@ namespace Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox;
 abstract class LayoutItem extends DialogBoxItem
 {
     /** @var array<int, TItem> */
-    private array $items;
+    private array $items = [];
 
     /**
      * @param list<TItem> $items


### PR DESCRIPTION
The error arises:
```
Typed property Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem::$items must not be accessed before initialization File: /var/www/html/vendor/teamneusta/pimcore-areabrick-config-bundle/src/EditableDialogBox/LayoutItem.php Line: 28

      #0 /var/www/html/vendor/teamneusta/pimcore-areabrick-config-bundle/src/EditableDialogBox/LayoutItem.php(66): Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem->isEmpty()
      #1 /var/www/html/vendor/teamneusta/pimcore-areabrick-config-bundle/src/EditableDialogBox/LayoutItem.php(53): Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem->isNotEmpty(Object(Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem\PanelItem))
      ...
```
and has to be fixed.