### PR TITLE
Revert "fix: Pimcore bug that reads default values of `checkbox` editables from different keys"

### DIFF
--- a/src/EditableDialogBox/EditableItem/CheckboxItem.php
+++ b/src/EditableDialogBox/EditableItem/CheckboxItem.php
@@ -17,7 +17,7 @@ class CheckboxItem extends EditableItem
      */
     public function setDefaultChecked(): static
     {
-        return $this->addConfig('default', true)->addConfig('defaultValue', true);
+        return $this->addConfig('defaultValue', true);
     }
 
     /**
@@ -25,6 +25,6 @@ class CheckboxItem extends EditableItem
      */
     public function setDefaultUnchecked(): static
     {
-        return $this->addConfig('default', false)->addConfig('defaultValue', false);
+        return $this->addConfig('defaultValue', false);
     }
 }


### PR DESCRIPTION
Reverts teamneusta/pimcore-areabrick-config-bundle#61

It turned out that the problem lay elsewhere, so this wasn't necessary.