### PR TITLE
refactor: replace title-based tab identification with name-based identification

### DIFF
--- a/src/DialogBoxBuilder.php
+++ b/src/DialogBoxBuilder.php
@@ -80,29 +80,49 @@ class DialogBoxBuilder
     }
 
     /**
+     * @deprecated since 3.1, use {@see self::addNamedTab()} instead.
+     *             Without a stable name, tabs cannot be referenced reliably when the title is translated.
+     *             Will become the default behavior (with a required name) in the next major version.
+     *
      * @return $this
      */
     public function addTab(string $title, EditableItem ...$items): static
     {
+        trigger_deprecation(
+            'teamneusta/pimcore-areabrick-config-bundle',
+            '3.1',
+            'Method "%s()" without a stable name is deprecated, use "%s::addNamedTab()" instead.',
+            __METHOD__,
+            self::class,
+        );
+
+        return $this->addNamedTab($title, $title, ...$items);
+    }
+
+    /**
+     * @return $this
+     */
+    public function addNamedTab(string $name, string $title, EditableItem ...$items): static
+    {
         $tabs = $this->getTabs();
 
-        if (!$tabs->hasTab($title)) {
-            $tabs->addTab(new PanelItem($title));
+        if (!$tabs->hasTab($name)) {
+            $tabs->addTab(new PanelItem($title, [], $name));
         }
 
-        $tabs->getTab($title)->addEditable(...$items);
+        $tabs->getTab($name)->addEditable(...$items);
 
         return $this;
     }
 
-    public function hasTab(string $title): bool
+    public function hasTab(string $name): bool
     {
-        return $this->getTabs()->hasTab($title);
+        return $this->getTabs()->hasTab($name);
     }
 
-    public function getTab(string $title): PanelItem
+    public function getTab(string $name): PanelItem
     {
-        return $this->getTabs()->getTab($title);
+        return $this->getTabs()->getTab($name);
     }
 
     public function getTabs(): TabPanelItem

--- a/src/EditableDialogBox/LayoutItem/PanelItem.php
+++ b/src/EditableDialogBox/LayoutItem/PanelItem.php
@@ -14,6 +14,7 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\LayoutItem;
  */
 class PanelItem extends LayoutItem implements \IteratorAggregate
 {
+    public readonly string $name;
     public readonly string $title;
 
     /** @var array<string, EditableItem> */
@@ -22,9 +23,20 @@ class PanelItem extends LayoutItem implements \IteratorAggregate
     /**
      * @param list<EditableItem> $items
      */
-    public function __construct(string $title, array $items = [])
+    public function __construct(string $title, array $items = [], ?string $name = null)
     {
         parent::__construct('panel', $items);
+
+        if (null === $name) {
+            trigger_deprecation(
+                'teamneusta/pimcore-areabrick-config-bundle',
+                '3.1',
+                'Not passing a "name" to "%s" is deprecated. Passing a "name" will be required in the next major version.',
+                self::class,
+            );
+        }
+
+        $this->name = $name ?? $title;
         $this->title = $title;
 
         foreach ($items as $item) {

--- a/src/EditableDialogBox/LayoutItem/TabPanelItem.php
+++ b/src/EditableDialogBox/LayoutItem/TabPanelItem.php
@@ -21,7 +21,7 @@ class TabPanelItem extends LayoutItem implements \IteratorAggregate
     public function __construct(array $items = [])
     {
         parent::__construct('tabpanel', $items);
-        $this->items = array_column($items, null, 'title');
+        $this->items = array_column($items, null, 'name');
     }
 
     /**
@@ -29,36 +29,36 @@ class TabPanelItem extends LayoutItem implements \IteratorAggregate
      */
     public function addTab(PanelItem $item): static
     {
-        if ($this->hasTab($item->title)) {
-            throw new \InvalidArgumentException(\sprintf('Tab with title "%s" already exists.', $item->title));
+        if ($this->hasTab($item->name)) {
+            throw new \InvalidArgumentException(\sprintf('A tab named "%s" already exists.', $item->name));
         }
 
-        $this->items[$item->title] = $item;
+        $this->items[$item->name] = $item;
 
         return $this->addItem($item);
     }
 
-    public function hasTab(string $title): bool
+    public function hasTab(string $name): bool
     {
-        return isset($this->items[$title]);
+        return isset($this->items[$name]);
     }
 
-    public function getTab(string $title): PanelItem
+    public function getTab(string $name): PanelItem
     {
-        return $this->items[$title]
-            ?? throw new \InvalidArgumentException(\sprintf('Tab with title "%s" not found.', $title));
+        return $this->items[$name]
+            ?? throw new \InvalidArgumentException(\sprintf('A tab named "%s" was not found.', $name));
     }
 
     /**
      * @return $this
      */
-    public function removeTab(string $title): static
+    public function removeTab(string $name): static
     {
-        if (!$item = $this->items[$title] ?? null) {
-            throw new \InvalidArgumentException(\sprintf('Tab with title "%s" not found.', $title));
+        if (!$item = $this->items[$name] ?? null) {
+            throw new \InvalidArgumentException(\sprintf('A tab named "%s" was not found.', $name));
         }
 
-        unset($this->items[$title]);
+        unset($this->items[$name]);
 
         return $this->removeItem($item);
     }


### PR DESCRIPTION
Starting with #51, the dialog box can be reconfigured. This creates a need to access tabs using a stable identifier. Previously, access was only possible via their “title.” However, since this is often a translated value, it is not particularly well-suited for this purpose. Therefore, a new identifier, “name,” is now being introduced to allow for stable access.