### PR TITLE
feat: support allowed subtypes and classes in `LinkItem`

### DIFF
--- a/src/EditableDialogBox/EditableItem/LinkItem.php
+++ b/src/EditableDialogBox/EditableItem/LinkItem.php
@@ -12,8 +12,10 @@ use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem;
  */
 class LinkItem extends EditableItem
 {
-    /** @var list<Types> */
+    /** @var array{asset?: list<string>, document?: list<string>, object?: list<string>} */
     private array $allowedTypes = [];
+    /** @var list<string> */
+    private array $allowedClasses = [];
     /** @var list<Targets> */
     private array $allowedTargets = [];
     /** @var list<Fields> */
@@ -25,15 +27,42 @@ class LinkItem extends EditableItem
     }
 
     /**
-     * @no-named-arguments
-     *
      * @param Types ...$types
      *
      * @return $this
      */
     public function allowTypes(string ...$types): self
     {
-        $this->allowedTypes = $types;
+        foreach ($types as $type) {
+            $this->addType($type, []);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function allowAssetsOfType(string ...$types): static
+    {
+        return $this->addType('asset', array_values($types));
+    }
+
+    /**
+     * @return $this
+     */
+    public function allowDocumentsOfType(string ...$types): static
+    {
+        return $this->addType('document', array_values($types));
+    }
+
+    /**
+     * @return $this
+     */
+    public function allowObjectsOfClass(string ...$classes): static
+    {
+        $this->addType('object', ['object']);
+        $this->allowedClasses = array_values($classes);
 
         return $this;
     }
@@ -69,9 +98,23 @@ class LinkItem extends EditableItem
     protected function defaultConfig(): array
     {
         return array_filter([
-            'allowedTypes' => $this->allowedTypes,
+            'allowedTypes' => array_keys($this->allowedTypes),
+            'allowedSubtypes' => array_filter($this->allowedTypes),
+            'allowedClasses' => $this->allowedClasses,
             'allowedTargets' => $this->allowedTargets,
             'disabledFields' => $this->disabledFields,
         ], static fn (array $item) => [] !== $item);
+    }
+
+    /**
+     * @param list<string> $subTypes
+     *
+     * @return $this
+     */
+    private function addType(string $type, array $subTypes): static
+    {
+        $this->allowedTypes[$type] = $subTypes;
+
+        return $this;
     }
 }

--- a/tests/Unit/EditableDialogBox/EditableItem/LinkItemTest.php
+++ b/tests/Unit/EditableDialogBox/EditableItem/LinkItemTest.php
@@ -1,0 +1,195 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\AreabrickConfigBundle\Tests\Unit\EditableDialogBox\EditableItem;
+
+use Neusta\Pimcore\AreabrickConfigBundle\EditableDialogBox\EditableItem\LinkItem;
+use PHPUnit\Framework\TestCase;
+
+class LinkItemTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCreatesLinkItemWithDefaultConfiguration(): void
+    {
+        $item = new LinkItem('test');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itAllowsTypes(): void
+    {
+        $item = new LinkItem('test');
+
+        $item->allowTypes('asset', 'document', 'object');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'allowedTypes' => ['asset', 'document', 'object'],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itAllowsAssetsOfSpecificTypes(): void
+    {
+        $item = new LinkItem('test');
+
+        $item->allowAssetsOfType('image', 'video');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'allowedTypes' => ['asset'],
+                    'allowedSubtypes' => [
+                        'asset' => ['image', 'video'],
+                    ],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itAllowsDocumentsOfSpecificTypes(): void
+    {
+        $item = new LinkItem('test');
+
+        $item->allowDocumentsOfType('page', 'snippet');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'allowedTypes' => ['document'],
+                    'allowedSubtypes' => [
+                        'document' => ['page', 'snippet'],
+                    ],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itAllowsObjectsOfSpecificClasses(): void
+    {
+        $item = new LinkItem('test');
+
+        $item->allowObjectsOfClass('Product', 'Category');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'allowedTypes' => ['object'],
+                    'allowedSubtypes' => [
+                        'object' => ['object'],
+                    ],
+                    'allowedClasses' => ['Product', 'Category'],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itAllowsTargets(): void
+    {
+        $item = new LinkItem('test');
+
+        $item->allowTargets('_blank', '_self');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'allowedTargets' => ['_blank', '_self'],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itDisallowsFields(): void
+    {
+        $item = new LinkItem('test');
+
+        $item->disallowFields('text', 'target', 'parameters');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'disabledFields' => ['text', 'target', 'parameters'],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itCombinesAllConfigurationOptions(): void
+    {
+        $item = new LinkItem('test');
+
+        $item
+            ->allowAssetsOfType('image')
+            ->allowDocumentsOfType('page')
+            ->allowObjectsOfClass('Product')
+            ->allowTargets('_blank')
+            ->disallowFields('anchor', 'title');
+
+        self::assertEquals(
+            [
+                'type' => 'link',
+                'name' => 'test',
+                'config' => [
+                    'allowedTypes' => ['asset', 'document', 'object'],
+                    'allowedSubtypes' => [
+                        'asset' => ['image'],
+                        'document' => ['page'],
+                        'object' => ['object'],
+                    ],
+                    'allowedClasses' => ['Product'],
+                    'allowedTargets' => ['_blank'],
+                    'disabledFields' => ['anchor', 'title'],
+                ],
+            ],
+            $item->toArray(),
+        );
+    }
+}


### PR DESCRIPTION
This is a feature of Pimcore `v12.3.10` / AdminUI Classic Bundle `v2.3.7` and will do nothing on lower versions.